### PR TITLE
added ability to import nested service groups

### DIFF
--- a/NsxObjectImport.ps1
+++ b/NsxObjectImport.ps1
@@ -192,14 +192,18 @@ ForEach ($ServiceGrpId in $ServiceGroupHash.Keys){
 		Foreach ($member in $ServiceGrpmember){
 			$membername = $member.name
 			If ($logon -eq "Yes") { Write-Log "[ADDING] ServiceGroup: $ServiceGrpname add member $membername" }
-			# Get the service id
-			$SvcGrChildId = Get-NsxService -name "$membername" -ErrorAction SilentlyContinue
+			# Get the member id - either a service or a service group
+			if ($member.objectTypeName -eq "Application") {
+			    $SvcGrChildId = Get-NsxService -name "$membername" -ErrorAction SilentlyContinue -connection $Connection
+			} else {
+			    $SvcGrChildId = Get-NsxServiceGroup -name "$membername" -ErrorAction SilentlyContinue -connection $Connection
+			}
 			If ($logon -eq "Yes") { Write-Log "[ADDING] ServiceGroup: $membername add memberID $SvcGrChildId" }
-			Get-NsxServiceGroup -name "$ServiceGrpname" | Add-NsxServiceGroupMember "$SvcGrChildId" -ErrorAction SilentlyContinue	
-		}
-		#New
-		$countadd=$countadd+1
-	}else{
+			Get-NsxServiceGroup -name "$ServiceGrpname" -connection $Connection | Add-NsxServiceGroupMember -Member $SvcGrChildId -ErrorAction SilentlyContinue -connection $Connection
+        	}
+        	#New
+        	$countadd=$countadd+1
+        }else{
 		#doesexist skip
 		If ($logon -eq "Yes") { Write-Log "[SKIP] Service Group: $Servicegrpname exists in NSX, skipping...." }
 		$countskip=$countskip+1


### PR DESCRIPTION
service group members can be either services or other service groups (nested)
this PR adds
- support for service groups as service group members
- rewords the log file to make more sense due to the new functionality
- explicitly defines the NSX connection variable to avoid nasty surprises